### PR TITLE
add MCP server badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 A [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) server designed for MCP clients, such as **Claude Desktop** or **CLine** in VSCode. This server can be used with any LLM when used with CLine. This server enables interaction with a running **Clojure nREPL instance**, allowing evaluation of Clojure code, namespace inspection, and other utilities via MCP.
 
+<a href="https://glama.ai/mcp/servers/st66euqse7"><img width="380" height="200" src="https://glama.ai/mcp/servers/st66euqse7/badge" alt="nREPL Server MCP server" /></a>
+
 ---
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [nREPL MCP Server](https://glama.ai/mcp/servers/st66euqse7) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/st66euqse7"><img width="380" height="200" src="https://glama.ai/mcp/servers/st66euqse7/badge" alt="nREPL Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.